### PR TITLE
Since quotes (' and ") are escaped in the DB like \" and \', displayi…

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -32,7 +32,7 @@
     <div class="movie-list">
         @foreach ($mostPopularMovies as $movie)
             <div class="movie-item">
-                <h3>{{ $movie->title }}</h3>
+                <h3>{{ stripslashes($movie->title) }}</h3>
                 @if($movie->poster_path)
                     <img src="https://image.tmdb.org/t/p/w500{{ $movie->poster_path }}" alt="{{ $movie->title }} poster">
                 @else

--- a/resources/views/movie-details.blade.php
+++ b/resources/views/movie-details.blade.php
@@ -8,16 +8,16 @@
 
       <div id="up">
       @if ($movie->poster_path)
-        <img class="movie-poster" src="https://image.tmdb.org/t/p/w500{{ $movie->poster_path }}" alt="{{ $movie->title }} poster">
+        <img class="movie-poster" src="https://image.tmdb.org/t/p/w500{{ $movie->poster_path }}" alt="{{ stripslashes($movie->title) }} poster">
       @else
           <br> <!-- Show a stock picture instead -->
       @endif
-        <h2>{{ $movie->title }}  <span> {{ ($movie->original_title) }}</span></h2>
+        <h2>{{ stripslashes($movie->title) }}  <span> {{ stripslashes($movie->original_title) }}</span></h2>
       @if ($movie->tagline)
-        <p>{{$movie->tagline}}</p>
+        <p>{{stripslashes($movie->tagline)}}</p>
       @endif
       @if ($movie->overview)
-        <p>{{$movie->overview}}</p>
+        <p>{{stripslashes($movie->overview)}}</p>
       @endif
       </div>
       <div id="bottom">


### PR DESCRIPTION
…ng them in the views also show the \, there is a php function called stripslashes() that remove them for us so I modified the views to call the fonction before showing the titles or the overviews