### PR TITLE
in user migration: changed 'permissions' from string to enum, with tw…

### DIFF
--- a/database/migrations/2024_06_13_093958_add_columns_users_table.php
+++ b/database/migrations/2024_06_13_093958_add_columns_users_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::table('users', function (Blueprint $table) {
             $table->string("username")->unique();
-            $table->string("permissions");
+            $table->enum("permissions", ["user", "admin"])->default("user");
             $table->string('avatar')->nullable();
             $table->string('badge')->nullable();
         });


### PR DESCRIPTION
…o possible values : 'user' or 'admin' by default, users are 'user'